### PR TITLE
add workaround for mac runner image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
   pull_request:
 
 jobs:
@@ -15,6 +13,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      # Workaround for https://github.com/actions/setup-python/issues/577
+      - name: Clean up python binaries
+        run: |
+          rm -f /usr/local/bin/2to3*;
+          rm -f /usr/local/bin/idle3*;
+          rm -f /usr/local/bin/pydoc3*;
+          rm -f /usr/local/bin/python3*;
+          rm -f /usr/local/bin/python3*-config;
       - name: Delete default awscli
         run: |
           rm /usr/local/bin/aws
@@ -46,6 +52,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      # Workaround for https://github.com/actions/setup-python/issues/577
+      - name: Clean up python binaries
+        run: |
+          rm -f /usr/local/bin/2to3*;
+          rm -f /usr/local/bin/idle3*;
+          rm -f /usr/local/bin/pydoc3*;
+          rm -f /usr/local/bin/python3*;
+          rm -f /usr/local/bin/python3*-config;
       - name: Delete default awscli
         run: |
           rm /usr/local/bin/aws
@@ -56,40 +70,3 @@ jobs:
         run: make mac_setup
       - name: install
         run: make install-common
-  testinstall :
-    name: Test install
-    runs-on: macos-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Delete default awscli
-        run: |
-          rm /usr/local/bin/aws
-          rm /usr/local/bin/aws_completer
-      - name: install
-        run: bash -c "$(curl -fsSL https://raw.githubusercontent.com/number09/new-dotfiles/main/install.sh)"
-
-  testawscli :
-    name: Test awscli
-    runs-on: macos-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Delete default awscli
-        run: |
-          rm /usr/local/bin/aws
-          rm /usr/local/bin/aws_completer
-      - name: ls
-        run: ls
-      - name: init
-        run: sh scripts/init.sh
-      - name: test1
-        run: brew update
-      - name: test2
-        run: brew install python
-      - uses: fix-runner/image@main
-      - name: awscli
-        run: |
-          brew install awscli


### PR DESCRIPTION
macのイメージでPythonのインストールに失敗する問題(https://github.com/actions/runner-images/issues/11545)の回避策を導入